### PR TITLE
text in shape

### DIFF
--- a/frontend/app/internal/component/tools/ToolBar.tsx
+++ b/frontend/app/internal/component/tools/ToolBar.tsx
@@ -6,6 +6,7 @@ import { SvgShape } from "~/internal/svg/svgShape/svgShape";
 import { GeneralDraggable } from "~/internal/svg/svgShape/draggable/GeneralDraggable";
 import { ConstraintMovable } from "~/internal/svg/svgShape/movable/ConstraintMovable";
 import { GeneralMovable } from "~/internal/svg/svgShape/movable/GeneralMovable";
+import { UseCaseShape } from "~/internal/svg/svgShape/shapes/UseCaseShape";
 
 
 interface DiagramProps {
@@ -16,7 +17,7 @@ export const ToolBar = ({svgContainer}: DiagramProps) => {
     const clickHandler = updateSvg(svgContainer, svg => {
         const constraint = new Box(0, 0, 1080, 720)
         const shape = new Circle({r: 50, cx: 100, cy: 100});
-        new SvgShape(shape, svg, new ConstraintMovable(shape, constraint)).setDraggable(new GeneralDraggable());
+        new UseCaseShape(shape, svg, constraint);
     })
 
     return (

--- a/frontend/app/internal/svg/svgShape/draggable/GeneralDraggable.ts
+++ b/frontend/app/internal/svg/svgShape/draggable/GeneralDraggable.ts
@@ -1,10 +1,10 @@
-import { Shape } from "@svgdotjs/svg.js";
+import { G, Shape } from "@svgdotjs/svg.js";
 import { Draggable } from "./Draggable";
 import { DragHandler } from "~/internal/svg/svgDraggable/svg.draggable"
 import { Movable } from "../movable/Movable";
 
 export class GeneralDraggable implements Draggable {
-    init(shape: Shape, movable: Movable) {
+    init(shape: Shape | G, movable: Movable) {
         new DragHandler(shape).init(true);
 
         const onDrag = (e: Event): void => {

--- a/frontend/app/internal/svg/svgShape/movable/ConstraintMovable.ts
+++ b/frontend/app/internal/svg/svgShape/movable/ConstraintMovable.ts
@@ -1,11 +1,11 @@
-import { Box, Shape } from "@svgdotjs/svg.js";
+import { Box, G, Shape } from "@svgdotjs/svg.js";
 import { Movable } from "./Movable";
 
 export class ConstraintMovable implements Movable {
     private shape: Shape;
     private constraint: Box;
 
-    constructor(shape: Shape, constraint: Box) {
+    constructor(shape: Shape | G, constraint: Box) {
         this.shape = shape;
         this.constraint = constraint;
     }

--- a/frontend/app/internal/svg/svgShape/shapes/UseCaseShape.ts
+++ b/frontend/app/internal/svg/svgShape/shapes/UseCaseShape.ts
@@ -49,7 +49,6 @@ export class UseCaseShape {
         this.rect.cx(cx).cy(cy);
     }
 
-
     private startEditing() {
         const prevText = this.textElement.text();
 
@@ -69,9 +68,11 @@ export class UseCaseShape {
 
         textarea.focus();
         textarea.addEventListener('blur', () => {
-            this.textElement.text(textarea.value);
-            this.updateTextAndRectPosition();
-            textarea.remove();
+            if (textarea.value != '') {
+                this.textElement.text(textarea.value);
+                this.updateTextAndRectPosition();
+            }
+                textarea.remove();
         });
         textarea.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {

--- a/frontend/app/internal/svg/svgShape/shapes/UseCaseShape.ts
+++ b/frontend/app/internal/svg/svgShape/shapes/UseCaseShape.ts
@@ -1,0 +1,83 @@
+import { Svg, Text, Rect, G, Circle, Shape, Box } from "@svgdotjs/svg.js";
+import { Draggable } from "../draggable/Draggable";
+import { Movable } from "../movable/Movable";
+import { ConstraintMovable } from "../movable/ConstraintMovable";
+import { GeneralDraggable } from "../draggable/GeneralDraggable";
+
+export class UseCaseShape {
+    private draggable?: Draggable;
+    private group: G;
+    private shape: Shape;
+    private textElement: Text;
+    private rect: Rect;
+    private svg: Svg;
+    private movable: Movable;
+
+    constructor(shape: Shape, svg: Svg, constraint: Box) {
+        this.shape = shape;
+        this.svg = svg;
+
+        this.group = new G();
+        this.group.add(this.shape);
+
+        this.textElement = new Text().plain('').font({ fill: 'white', size: 16, anchor: 'middle' });
+        this.group.add(this.textElement);
+
+        this.rect = new Rect().width(100).height(30).fill('transparent').stroke({ color: 'white', width: 1 }).opacity(0);
+        this.group.add(this.rect);
+
+        svg.add(this.group);
+        this.movable = new ConstraintMovable(this.group, constraint);
+        this.setDraggable(new GeneralDraggable());
+
+        this.updateTextAndRectPosition();
+
+        this.rect.on('click', () => this.startEditing());
+    }
+
+    public setDraggable(draggable: Draggable): UseCaseShape {
+        this.draggable = draggable;
+        this.draggable.init(this.group, this.movable);
+        return this;
+    }
+
+    private updateTextAndRectPosition() {
+        const cx = this.shape.cx();
+        const cy = this.shape.cy();
+        this.textElement.cx(cx);
+        this.textElement.cy(cy);
+        this.rect.cx(cx).cy(cy);
+    }
+
+
+    private startEditing() {
+        const prevText = this.textElement.text();
+
+
+        const textarea = document.createElement('textarea');
+        textarea.value = this.textElement.text();
+        textarea.style.position = 'absolute';
+
+        const { left, top, width, height } = this.group.node.getBoundingClientRect();
+        textarea.style.left = `${left + width / 2}px`;
+        textarea.style.top = `${top + height / 2}px`;
+        textarea.style.transform = 'translate(-50%, -50%)';
+        textarea.style.fontSize = '16px';
+        textarea.style.padding = '4px';
+
+        document.body.appendChild(textarea);
+
+        textarea.focus();
+        textarea.addEventListener('blur', () => {
+            this.textElement.text(textarea.value);
+            this.updateTextAndRectPosition();
+            textarea.remove();
+        });
+        textarea.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                textarea.value = prevText;
+                textarea.blur();
+            }
+        });
+    }
+}


### PR DESCRIPTION
Чтобы текст водился вместе с фигурой без костылей(сторонних функций перемещения текста) надо добавить текст и фигуру в группу. В текущем классе SvgShape это сделать невозможно, потому что надо передавать сразу в ConstraintMovable() shape(группу еще не создали чтобы передать), значит будет двигаться только сам шейп, а текст нет. Поэтому пришлось добавить обертку UseCaseShape, название такое потому что препод говорил про два типа диаграмм: юзкейс и классов, потом сделаем для классов.